### PR TITLE
Fixed strict warning

### DIFF
--- a/Model/Datasource/SoapSource.php
+++ b/Model/Datasource/SoapSource.php
@@ -110,9 +110,10 @@ class SoapSource extends DataSource {
 /**
  * Returns the available SOAP methods
  *
+ * @param mixed $data Unused in this class.
  * @return array List of SOAP methods
  */
-	public function listSources() {
+	public function listSources($data = null) {
 		return $this->client->__getFunctions();
 	}
 


### PR DESCRIPTION
Fixed: `Declaration of SoapSource::listSources()` should be compatible with `DataSource::listSources($data = NULL)`